### PR TITLE
add dataproc wrapper for extraction

### DIFF
--- a/datasets/acute-care/extract_trio_vcf.py
+++ b/datasets/acute-care/extract_trio_vcf.py
@@ -5,7 +5,6 @@ import logging
 import os
 import sys
 
-from google.cloud import storage
 from itertools import chain
 from typing import Optional
 

--- a/datasets/acute-care/extraction_wrapper.py
+++ b/datasets/acute-care/extraction_wrapper.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+"""
+Wrapper script to initiate a hail batch, and submit using an analysis-runner managed dataproc cluster
+"""
+import hailtop.batch as hb
+import os
+import sys
+
+from analysis_runner import dataproc
+
+
+def main():
+    """
+    Create a Hail Batch
+    Use the analysis-runner helper to generate a DataProc cluster, and add the job
+    Set off the batch
+    """
+
+    service_backend = hb.ServiceBackend(
+        billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+    )
+
+    # create a hail batch
+    batch = hb.Batch(name='cohort_mt_extraction', backend=service_backend)
+
+    my_cluster = dataproc.hail_dataproc_job(
+        batch=batch,
+        script=" ".join(sys.argv[1:]),
+        max_age='4h',
+        job_name="extract_from_cohort_mt",
+        num_secondary_workers=4,
+        cluster_name='cohort_mt_extraction with max-age=4h',
+    )
+
+    batch.run(wait=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: fewgenomes
 
 dependencies:
+  - analysis-runner
   - snakemake-minimal
   - pandas
   - google-cloud-sdk


### PR DESCRIPTION
Initial attempts failed as the submitted jobs weren't using dataproc, meaning they had no access to the gs:// paths. This creates a wrapper script which creates a hail batch, and within that passes all script arguments as a dataproc job.

Plan would be to submit the wrapper as an analysis-runner job, which will forward the extraction scripts and all arguments as a nested job, which will then have access to the required data.