### PR TITLE
copy script for expanded slivar

### DIFF
--- a/datasets/acute-care/copy_slivar_with_vep_split.sh
+++ b/datasets/acute-care/copy_slivar_with_vep_split.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+skopeo copy docker://docker.io/mwellandcpg/slivar:vep_split docker://australia-southeast1-docker.pkg.dev/cpg-common/images/slivar:vep_split


### PR DESCRIPTION
added a second Slivar copy script

The original image (brentp/slivar:v0.2.7) contains bcftools 1.13 and has the plugin split-vep present, but is not installed correctly. i.e.

```
bcftools +split-vep
[E::main] unrecognized command 'plugin'
```

following a simple extension of the original Docker build (see new layers 11 & 12 here: [mwellandcpg:slivar](https://hub.docker.com/layers/190498041/mwellandcpg/slivar/vep_split/images/sha256-0970b9a82f39ab1a4b1f33ed3a2c1f9a7aa69c1274ac565d8639a807fc743e9b?context=repo)) bcftools 1.14is installed, overwriting the original installation, and crucially the plugins are present and working. 

This MR adds a new script to copy the adapted slivar image into the CPG artifactory.

This new container will facilitate ad hoc scripted analysis of VEP-annotated VCFs using Slivar, without having to alter the content of the base slivar container with each run.